### PR TITLE
Mount the Flask app instead of both copying and mounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 cucumber/hellocucumber/target
 cucumber/hellocucumber/maven-repository
-flask/app/__pycache__/main.cpython-38.pyc
 hellocucumber/.idea
 .idea/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A starter project if you need Behavior-driven Development with Cucumber, Selenium, a remote WebDriver and the Page Object Model.  All running in Docker.
 
+The `flask` service uses `flask run` to start a simple development webserver.  The development webserver is not suitable for use in production.
+
 ## Starting and stopping the containers
 ````
 docker compose up -d --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 4444:4444
       - 5900:5900
   flask:
-    build: ./flask
+    image: tiangolo/uwsgi-nginx-flask:python3.8
     volumes:
       - ./flask/app:/app
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,5 @@ services:
     environment:
       - FLASK_APP=main.py
       - FLASK_DEBUG=1
+      - PYTHONPYCACHEPREFIX=/tmp/pycache
     command: flask run --host=0.0.0.0 --port=80

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,3 +1,0 @@
-FROM tiangolo/uwsgi-nginx-flask:python3.8
-
-COPY ./app /app


### PR DESCRIPTION
Prior to this the Flask app is both copied into a custom Docker image and mounted as a volume. This branch removes the custom Docker image. A couple of other minor changes are included.